### PR TITLE
Fix delete lesson on students page not showing lessons page

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -138,6 +138,7 @@ public class ModelManager implements Model {
     public void deleteLesson(Lesson lesson) {
         requireNonNull(lesson);
         addressBook.removeLesson(lesson);
+        updateFilteredLessonList(PREDICATE_SHOW_ALL_LESSONS);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/DeleteLessonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLessonCommandTest.java
@@ -63,7 +63,6 @@ public class DeleteLessonCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteLesson(lessonToDelete);
-        showNoLesson(expectedModel);
 
         assertCommandSuccess(deleteLessonCommand, model, expectedResult, expectedModel);
     }
@@ -122,9 +121,9 @@ public class DeleteLessonCommandTest {
     /**
      * Updates {@code model}'s filtered list to show no one.
      */
-    private void showNoLesson(Model model) {
-        model.updateFilteredLessonList(p -> false);
+    private void showNoStudent(Model model) {
+        model.updateFilteredStudentList(p -> false);
 
-        assertTrue(model.getFilteredLessonList().isEmpty());
+        assertTrue(model.getFilteredStudentList().isEmpty());
     }
 }


### PR DESCRIPTION
Fixed the page not changing issue by adding the update lesson list function in Model. Now when the user deletes a lesson, it automatically shows the lessons page.