### PR TITLE
Change same student criteria

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddStudentCommand.java
@@ -37,7 +37,8 @@ public class AddStudentCommand extends Command {
             + "s/ Math";
 
     public static final String MESSAGE_SUCCESS = "New student added: %1$s";
-    public static final String MESSAGE_DUPLICATE_STUDENT = "This student already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_STUDENT = "A student with the same name, email, or phone number "
+            + "already exists in the address book";
 
     private static final Logger logger = LogsCenter.getLogger(AddStudentCommand.class);
 

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -130,7 +130,7 @@ public class Student {
     }
 
     /**
-     * Returns true if both students have the same name.
+     * Returns true if both students have the same name or phone or email.
      * This defines a weaker notion of equality between two students.
      */
     public boolean isSameStudent(Student otherStudent) {
@@ -138,8 +138,8 @@ public class Student {
             return true;
         }
 
-        return otherStudent != null
-                && otherStudent.getName().equals(getName());
+        return otherStudent != null && (otherStudent.getName().equals(this.getName())
+                || otherStudent.getPhone().equals(this.getPhone()) || otherStudent.getEmail().equals(this.getEmail()));
     }
 
     /**

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -34,13 +34,14 @@ public class StudentTest {
         // null -> returns false
         assertFalse(ALICE.isSameStudent(null));
 
-        // same name, all other attributes different -> returns true
-        Student editedAlice = new StudentBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withSubjects(VALID_SUBJECT_HUSBAND).build();
+        // same name, phone, email but all other attributes different -> returns true
+        Student editedAlice = new StudentBuilder(ALICE).withAddress(VALID_ADDRESS_BOB)
+                .withSubjects(VALID_SUBJECT_HUSBAND).build();
         assertTrue(ALICE.isSameStudent(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new StudentBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // different name, email and phone, all other attributes same -> returns false
+        editedAlice = new StudentBuilder(ALICE).withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB).build();
         assertFalse(ALICE.isSameStudent(editedAlice));
 
         // name differs in case, all other attributes same -> returns true


### PR DESCRIPTION
Changed identifying duplicate student by name to by any of name, phone number, or email. This will disallow duplicate phone numbers and email while allowing students with same names but different phone numbers and emails to be added.